### PR TITLE
Remove the outlet attribute from markup.

### DIFF
--- a/space-pen-spec.coffee
+++ b/space-pen-spec.coffee
@@ -45,6 +45,10 @@ describe "View", ->
         expect(view.li1).toMatchSelector "li.foo:contains(one)"
         expect(view.li2).toMatchSelector "li.bar:contains(two)"
 
+      it "removes the outlet attribute from markup", ->
+        expect(view.li1.attr('outlet')).toBeUndefined()
+        expect(view.li2.attr('outlet')).toBeUndefined()
+
       it "constructs and wires outlets for subviews", ->
         expect(view.subview).toExist()
         expect(view.subview.find('h2:contains(Subview)')).toExist()

--- a/space-pen.coffee
+++ b/space-pen.coffee
@@ -73,7 +73,9 @@ class View extends jQuery
   wireOutlets: (view) ->
     @find('[outlet]').each ->
       element = $(this)
-      view[element.attr('outlet')] = element
+      outlet = element.attr('outlet')
+      view[outlet] = element
+      element.attr('outlet', null)
 
   bindEventHandlers: (view) ->
     for eventName in events


### PR DESCRIPTION
Avoids some tag soup on the builders markup by removing the outlet attribute after the views property is set.
