### PR TITLE
Use element data vs. attributes for space-pen attach trigger hints.

### DIFF
--- a/space-pen.coffee
+++ b/space-pen.coffee
@@ -58,8 +58,7 @@ class View extends jQuery
     @constructor = jQuery # sadly, jQuery assumes this.constructor == jQuery in pushStack
     @wireOutlets(this)
     @bindEventHandlers(this)
-    @find('*').andSelf().data('view', this)
-    @attr('triggerAttachEvents', true)
+    @find('*').andSelf().data('view', this).data('spTriggerAttachEvent', true)
     step(this) for step in postProcessingSteps
     @initialize?(params)
 
@@ -158,8 +157,8 @@ jQuery.fn.view = -> this.data('view')
 
 # Trigger attach event when views are added to the DOM
 triggerAttachEvent = (element) ->
-  if element.attr?('triggerAttachEvents') and element.parents('html').length
-    element.find('[triggerAttachEvents]').add(element).trigger('attach')
+  if element?.data?('spTriggerAttachEvent') and element.parents('html').length
+    element.find('*').andSelf().filter(-> $(this).data('spTriggerAttachEvent')).trigger('attach')
 
 for methodName in ['append', 'prepend', 'after', 'before']
   do (methodName) ->


### PR DESCRIPTION
Like issue #2, this keeps space-pen attributes out of the markup, but for attach triggers. This does a few things.

1) Stores the "spTriggerAttachEvent" string in data(). Uses a "sp" prefix for space-pen to avoid conflicts.

2) It changes triggerAttachEvent() to work with the data attribute. Note this function also has a subtle change where it has an extra existential operator at the beginning `if element?` since I found that in some odd cases where my dom sublists were empty the append was passing undefined. Could not track down by, so thought the extra guard was just OK.

All tests pass.
