### PR TITLE
Added more supported events (focusin/focusout) & id/class definition via CSS selectors

### DIFF
--- a/space-pen-spec.coffee
+++ b/space-pen-spec.coffee
@@ -19,8 +19,8 @@ describe "View", ->
             @div "#first-id.then_class", "w/other content"
             @div "#id", "w/content", data: "and attrs"
             @div "#id", data: "w/attrs", "and content"
-            @div ".B&W?", "w/content"
             @div ".treated-as#content"
+            @div "also-treated-as#content", data: "test"
             @div "#first-id#second-id", "w/content"
             @div ".1bad-identifier#-2bad-identifier", "w/content"
 
@@ -98,12 +98,17 @@ describe "View", ->
         expect(view.subview.view()).toBe view.subview
         expect(view.subview.header.view()).toBe view.subview
 
+      it "renders content when the first argument doesn't start with '.' or '#'", ->
+        expect(view.find("also-treated-as#content")).not.toExist()
+        expect(view.find("[data='test']:contains(also-treated-as#content)")).toExist()
+
       describe "when the first argument is a selector", ->
         it "renders an element with appropriate class and id", ->
           expect(view.find(".first1class#then-id")).toHaveText("w/content")
           expect(view.find("#first-id.then_class")).toHaveText("w/other content")
 
         it "renders the selector as content when it is the only argument", ->
+          expect(view.find(".treated-as#content")).not.toExist()
           expect(view.find(":contains(.treated-as#content)")).toExist()
 
         it "only renders one id", ->

--- a/space-pen.coffee
+++ b/space-pen.coffee
@@ -171,7 +171,7 @@ class Builder
     options
     
   processSelector: (args) ->
-    if args.length > 1 and typeof args[0] is "string"
+    if args.length > 1 and typeof args[0] is "string" and /^[\.#]/.test args[0]
       selectorStr = args.shift()
       attrs = {}
 


### PR DESCRIPTION
Jeremy and I added `focusin` and `focusout` event support (we were using it on our project).

We also added the ability to define ids and classes via CSS selectors. If a tag is given more than one argument, the first argument is considered a CSS selector if it starts with `.` or `#`.

```
@div ".first1class#then-id", "w/content"
@div "#first-id.then_class", "w/other content"
@div ".treated-as#content"
@div "also-treated-as#content", data: "test"
```
