### PR TITLE
Handling HTML5 data attributes containing inline json data.

### DIFF
--- a/space-pen.coffee
+++ b/space-pen.coffee
@@ -114,7 +114,7 @@ class Builder
   openTag: (name, attributes) ->
     attributePairs =
       for attributeName, value of attributes
-        "#{attributeName}=\"#{value}\""
+        "#{attributeName}='#{value}'"
 
     attributesString =
       if attributePairs.length


### PR DESCRIPTION
Thanks Nathan for this beautiful little piece of gem.

HTML5 data attributes can sometime contain json data structure. Browsers parse these values into json automatically. However, this requires attribute values to be wrapped around single quotes. See this [link](http://stackoverflow.com/questions/7410348/how-to-set-json-format-to-html5-data-attributes-in-the-jquery) for more elaborate explanation. 

Currently, space-pen wraps attribute values with double quotes. I have changed that to single quotes to take care of above scenario.
