### PR TITLE
Support for older IE versions (8 and below).

### DIFF
--- a/space-pen.coffee
+++ b/space-pen.coffee
@@ -22,8 +22,10 @@ idCounter = 0
 class View extends jQuery
   @builderStack: []
 
-  elements.forEach (tagName) ->
-    View[tagName] = (args...) -> @currentBuilder.tag(tagName, args...)
+  for tagName in elements
+    View[tagName] = do ->
+      _tagName = tagName
+      (args...) -> @currentBuilder.tag(_tagName, args...)
 
   @subview: (name, view) ->
     @currentBuilder.subview(name, view)


### PR DESCRIPTION
Just a simple replacement of the elements.forEach for a more IE-friendly alternative since Internet Explorer versions 8 and below do not support the method Array.forEach.
