### PR TITLE
Be more defensive when looking for handlers.

### DIFF
--- a/spec/jquery-extensions-spec.coffee
+++ b/spec/jquery-extensions-spec.coffee
@@ -146,6 +146,10 @@ describe 'jQuery extensions', ->
       expect(view.scrollTop()).toBe 0
 
   describe "$.fn.handlers(eventName)", ->
+    it "returns no handlers when the element does not exist", ->
+      view = $('.notinthepageoranything')
+      expect(view.handlers()).toEqual {}
+
     it "returns all registered event handlers", ->
       view = $$ -> @div('div')
 

--- a/src/jquery-extensions.coffee
+++ b/src/jquery-extensions.coffee
@@ -92,7 +92,7 @@ $.fn.preempt = (eventName, handler) ->
 # event name isn't specified or an array of event handlers if an event name is
 # specified. This method never returns null or undefined.
 $.fn.handlers = (eventName) ->
-  handlers = $._data(this[0], 'events') ? {}
+  handlers = if this.length then $._data(this[0], 'events') ? {} else {}
   handlers = handlers[eventName] ? [] if arguments.length is 1
   handlers
 


### PR DESCRIPTION
`jQuery._data()` cannot handle when the element does not exist
