### PR TITLE
Document View::command and View::preempt

### DIFF
--- a/src/space-pen.coffee
+++ b/src/space-pen.coffee
@@ -160,7 +160,7 @@ class View extends jQuery
   command: (commandName, selector, options, handler) ->
     super(commandName, selector, options, handler)
 
-  # Public: Force an event handler to be called before all others. Mimics the
+  # Public: Preempt events registered with jQuery's `::on`.
   #
   # eventName - A event name {String}.
   # handler - A {Function} to execute when the eventName is triggered.


### PR DESCRIPTION
People in atom/vim-mode had questions about these methods but they weren't doc'd. I think we should doc them because they are helpful for packages like vim-mode. Exposing View::preempt is a little scary, but I  think it is worth it.

I delegate through to the jquery-extension methods because we might use those methods in non-view objects.

/via atom/atom#1620
