### PR TITLE
Don't rely on 'webkitMatchesSelector', find out prefix on load instead

### DIFF
--- a/src/space-pen.coffee
+++ b/src/space-pen.coffee
@@ -22,6 +22,12 @@ Events =
    keypress keyup load mousedown mousemove mouseout mouseover
    mouseup resize scroll select submit unload'.split /\s+/
 
+# Use native matchesSelector if available, otherwise fall back
+# on jQuery.is (slower, but compatible)
+docEl = document.documentElement
+matches = docEl.matchesSelector || docEl.mozMatchesSelector || docEl.webkitMatchesSelector || docEl.oMatchesSelector || docEl.msMatchesSelector
+matchesSelector = if matches then ((elem, selector) -> matches.call(elem[0], selector)) else ((elem, selector) -> elem.is(selector))
+
 idCounter = 0
 
 # Public: View class that extends the jQuery prototype.
@@ -127,7 +133,7 @@ class View extends jQuery
           element = $(element)
           element.on eventName, (event) -> view[methodName](event, element)
 
-      if view.matching(selector)
+      if matchesSelector(view, selector)
         methodName = view[0].getAttribute(eventName)
         do (methodName) ->
           view.on eventName, (event) -> view[methodName](event, view)
@@ -239,9 +245,6 @@ class Builder
 
 jQuery.fn.view = -> @data('view')
 jQuery.fn.views = -> @toArray().map (elt) -> $(elt).view()
-docEl = document.documentElement
-matches = docEl.matchesSelector || docEl.mozMatchesSelector || docEl.webkitMatchesSelector || docEl.oMatchesSelector || docEl.msMatchesSelector
-jQuery.fn.matching = if matches then ((selector) -> matches.call(@[0], selector)) else jQuery.fn.is
 
 # Trigger attach event when views are added to the DOM
 callAttachHook = (element) ->


### PR DESCRIPTION
Pull request #21 was definitely a welcome performance improvement, but it made space-pen completely unusable on non-webkit browsers for me.

I've tried adapting this [jsperf test](http://jsperf.com/mozmatchesselector/11) to use the browser-specific version of 'matchesElement' (which will probably be prefixed for quite some time still).

The prefix sniffing is only done once, on load, and where the other jQuery functions are added (view, views) but the code might not look as clean as per atom standards - let me know if you can think of a better way and I'll happily adapt it.

With that change, I don't think there's any change in runtime performance, and it supports latest Firefox again (along with older IEs, probably, since it fallbacks on jQuery.is).
