### PR TITLE
data object into data-attributes like HAML

### DIFF
--- a/spec/space-pen-spec.coffee
+++ b/spec/space-pen-spec.coffee
@@ -24,7 +24,7 @@ describe "View", ->
 
         @list: ->
           @ol =>
-            @li outlet: 'li1', click: 'li1Clicked', class: 'foo', "one"
+            @li outlet: 'li1', click: 'li1Clicked', data: {first: "yes", date: "today"}, class: 'foo', "one"
             @li outlet: 'li2', keypress:'li2Keypressed', class: 'bar', "two"
 
         initialize: (args...) ->
@@ -66,6 +66,10 @@ describe "View", ->
       it "does not overwrite outlets on the superview with outlets from the subviews", ->
         expect(view.header).toMatchSelector "h1"
         expect(view.subview.header).toMatchSelector "h2"
+
+      it "decomposes a data object into many data attributes", ->
+        expect(view.li1.data('first')).toBe 'yes'
+        expect(view.li1.data('date')).toBe 'today'
 
       it "binds events for elements with event name attributes", ->
         spyOn(view, 'viewClicked').andCallFake (event, elt) ->

--- a/spec/space-pen-spec.coffee
+++ b/spec/space-pen-spec.coffee
@@ -25,7 +25,7 @@ describe "View", ->
         @list: ->
           @ol =>
             @li outlet: 'li1', click: 'li1Clicked', data: {first: "yes", date: "today"}, class: 'foo', "one"
-            @li outlet: 'li2', keypress:'li2Keypressed', class: 'bar', "two"
+            @li outlet: 'li2', keypress:'li2Keypressed', data: {foo: {first: "yes", date: "today"}, bar: false}, class: 'bar', "two"
 
         initialize: (args...) ->
           @initializeCalledWith = args
@@ -70,6 +70,11 @@ describe "View", ->
       it "decomposes a data object into many data attributes", ->
         expect(view.li1.data('first')).toBe 'yes'
         expect(view.li1.data('date')).toBe 'today'
+
+      it "decomposes a nested objects into many prefixed attributes", ->
+        expect(view.li2.data('foo-first')).toBe 'yes'
+        expect(view.li2.data('foo-date')).toBe 'today'
+        expect(view.li2.data('bar')).toBe false
 
       it "binds events for elements with event name attributes", ->
         spyOn(view, 'viewClicked').andCallFake (event, elt) ->

--- a/src/space-pen.coffee
+++ b/src/space-pen.coffee
@@ -225,9 +225,15 @@ class Builder
       attributes ?= {}
       attributes.is ?= registerElement(name)
 
+    if attributes?.data?
+      dataAttributes = " #{@dataAttribute 'data', attributes.data}"
+      delete attributes.data
+    else
+      dataAttributes = ""
+
     attributePairs =
       for attributeName, value of attributes
-        @attributePair attributeName, value
+        "#{attributeName}=\"#{value}\""
 
     attributesString =
       if attributePairs.length
@@ -235,14 +241,14 @@ class Builder
       else
         ""
 
-    @document.push "<#{name}#{attributesString}>"
+    @document.push "<#{name}#{attributesString}#{dataAttributes}>"
 
-  attributePair: (attributeName, value, prefix) ->
+  dataAttribute: (attributeName, value, prefix) ->
     attributeName = "#{prefix}-#{attributeName}" if prefix?
     if typeof(value) is 'object'
       nestedAttributes =
         for nestedAttribute, nestedValue of value
-          @attributePair(nestedAttribute, nestedValue, attributeName)
+          @dataAttribute(nestedAttribute, nestedValue, attributeName)
       nestedAttributes.join(" ")
     else
       "#{attributeName}=\"#{value}\""

--- a/src/space-pen.coffee
+++ b/src/space-pen.coffee
@@ -227,13 +227,7 @@ class Builder
 
     attributePairs =
       for attributeName, value of attributes
-        if attributeName is "data"
-          dataAttributes =
-            for dataAttribute, dataValue of value
-              "data-#{dataAttribute}=\"#{dataValue}\""
-          dataAttributes.join(" ")
-        else
-          "#{attributeName}=\"#{value}\""
+        @attributePair attributeName, value
 
     attributesString =
       if attributePairs.length
@@ -242,6 +236,16 @@ class Builder
         ""
 
     @document.push "<#{name}#{attributesString}>"
+
+  attributePair: (attributeName, value, prefix) ->
+    attributeName = "#{prefix}-#{attributeName}" if prefix?
+    if typeof(value) is 'object'
+      nestedAttributes =
+        for nestedAttribute, nestedValue of value
+          @attributePair(nestedAttribute, nestedValue, attributeName)
+      nestedAttributes.join(" ")
+    else
+      "#{attributeName}=\"#{value}\""
 
   closeTag: (name) ->
     @document.push "</#{name}>"

--- a/src/space-pen.coffee
+++ b/src/space-pen.coffee
@@ -227,7 +227,13 @@ class Builder
 
     attributePairs =
       for attributeName, value of attributes
-        "#{attributeName}=\"#{value}\""
+        if attributeName is "data"
+          dataAttributes =
+            for dataAttribute, dataValue of value
+              "data-#{dataAttribute}=\"#{dataValue}\""
+          dataAttributes.join(" ")
+        else
+          "#{attributeName}=\"#{value}\""
 
     attributesString =
       if attributePairs.length


### PR DESCRIPTION
I really enjoy HAMLs feature, wrapping data attributes into an object.

``` CoffeeScript
@div id: 'before', 'data-start': "last Year", 'data-end': "next Year"
@div id: 'now', data: {start: "last Year", end: "next Year"}
```
