### PR TITLE
View.render now works with table elements.

### DIFF
--- a/spec/space-pen-spec.coffee
+++ b/spec/space-pen-spec.coffee
@@ -168,6 +168,21 @@ describe "View", ->
       expect(fragment.find('div#subview')).toExist()
       expect(fragment.foo).toMatchSelector('#subview')
 
+    it "renders table elements", ->
+      tr    = $$ -> @tr()
+      td    = $$ -> @td()
+      tfoot = $$ -> @tfoot()
+      thead = $$ -> @thead()
+      tbody = $$ -> @tbody()
+      col   = $$ -> @col()
+
+      expect(tr).toMatchSelector('tr')
+      expect(td).toMatchSelector('td')
+      expect(tfoot).toMatchSelector('tfoot')
+      expect(thead).toMatchSelector('thead')
+      expect(tbody).toMatchSelector('tbody')
+      expect(col).toMatchSelector('col')
+
   describe "$$$", ->
     it "returns the raw HTML constructed by tag methods called by the given function (not a jQuery wrapper)", ->
       html = $$$ ->

--- a/src/space-pen.coffee
+++ b/src/space-pen.coffee
@@ -118,9 +118,7 @@ class View extends jQuery
 
   @render: (fn) ->
     [html, postProcessingSteps] = @buildHtml(fn)
-    div = document.createElement('div')
-    div.innerHTML = html
-    fragment = $(div.childNodes)
+    fragment = $(html)
     step(fragment) for step in postProcessingSteps
     fragment
 


### PR DESCRIPTION
This fix allows to have table elements as root element for the `View.render` method.

``` CoffeeScript
View.render ->
  @tr =>
    @td "data 1"
    @td "data 2"
```
