### PR TITLE
Placeholder for subviews uses the same tag as the subviews root tag.

### DIFF
--- a/spec/space-pen-spec.coffee
+++ b/spec/space-pen-spec.coffee
@@ -67,6 +67,26 @@ describe "View", ->
         expect(view.header).toMatchSelector "h1"
         expect(view.subview.header).toMatchSelector "h2"
 
+      it "inserts subviews with tr on the proper position", ->
+        class RowView extends View
+          @content: (row) ->
+            @tr =>
+              @td row[0]
+
+        class TableView extends View
+          @content: (rows) ->
+            @table =>
+              @thead =>
+                @th "header 1"
+              @tbody =>
+                for row, index in rows
+                  @subview "row_#{index}", new RowView(row)
+
+        table_view = new TableView([["1"], ["2"]])
+        expect(table_view.row_0).toMatchSelector "tr"
+        expect(table_view.row_1).toMatchSelector "tr"
+        expect(table_view.row_0.parent()).toMatchSelector "tbody"
+
       it "binds events for elements with event name attributes", ->
         spyOn(view, 'viewClicked').andCallFake (event, elt) ->
           expect(event.type).toBe 'keydown'

--- a/src/space-pen.coffee
+++ b/src/space-pen.coffee
@@ -255,11 +255,12 @@ class Builder
 
   subview: (outletName, subview) ->
     subviewId = "subview-#{++idCounter}"
-    @tag 'div', id: subviewId
+    subviewTagName = subview[0].nodeName
+    @tag subviewTagName, id: subviewId
     @postProcessingSteps.push (view) ->
       view[outletName] = subview
       subview.parentView = view
-      view.find("div##{subviewId}").replaceWith(subview)
+      view.find("#{subviewTagName}##{subviewId}").replaceWith(subview)
 
   extractOptions: (args) ->
     options = {}


### PR DESCRIPTION
Space-pen's subview method uses a div as a placeholder for subviews to be inserted on postProssesing.
This has a bug on tables, as discovered on https://github.com/atom/space-pen/issues/31, because `<div>` is not a valid child of `<tbody>` and ends up rendered outside the table before replacing it with the subview.
I propose to use the same tag as the subviews root-tag as a placeholder, this way it won't be misplaced before postProssesing.
By the way, loving this library so far!!!
