### PR TITLE
Small refactor to the matches selector

### DIFF
--- a/src/space-pen.coffee
+++ b/src/space-pen.coffee
@@ -27,9 +27,14 @@ Events =
 
 # Use native matchesSelector if available, otherwise fall back
 # on jQuery.is (slower, but compatible)
-docEl = document.documentElement
-matches = docEl.matchesSelector || docEl.mozMatchesSelector || docEl.webkitMatchesSelector || docEl.oMatchesSelector || docEl.msMatchesSelector
-matchesSelector = if matches then ((elem, selector) -> matches.call(elem[0], selector)) else ((elem, selector) -> elem.is(selector))
+matchesSelector = do (docEl = document.documentElement) ->
+  nativeMatchesSelector = docEl.matchesSelector ||
+    docEl.webkitMatchesSelector || docEl.mozMatchesSelector ||
+    docEl.oMatchesSelector      || docEl.msMatchesSelector
+  if nativeMatchesSelector?
+    (elem, selector) -> nativeMatchesSelector.call(elem[0], selector)
+  else
+    (elem, selector) -> elem.is(selector)
 
 idCounter = 0
 


### PR DESCRIPTION
This way we keep `docEl` and `matches` as scoped variables since they are not needed elsewhere.
Also renamed `matches` to `nativeMatchesSelector` to better follow the comment.

By the way, nice pull request https://github.com/atom/space-pen/pull/29.
