### PR TITLE
dasherize camelCased element attributes

### DIFF
--- a/spec/space-pen-spec.coffee
+++ b/spec/space-pen-spec.coffee
@@ -26,6 +26,7 @@ describe "View", ->
           @ol =>
             @li outlet: 'li1', click: 'li1Clicked', class: 'foo', "one"
             @li outlet: 'li2', keypress:'li2Keypressed', class: 'bar', "two"
+            @li outlet: 'li3', dataCustomAttribute:'dasherize me'
 
         initialize: (args...) ->
           @initializeCalledWith = args
@@ -47,6 +48,10 @@ describe "View", ->
 
       it "calls initialize on the view with the given params", ->
         expect(view.initializeCalledWith).toEqual([{title: "Zebra"}, 42])
+
+      it "dasherizes camelCased attributes", ->
+        expect(view.li3.attr('dataCustomAttribute')).toBeUndefined()
+        expect(view.li3.attr('data-custom-attribute')).toEqual('dasherize me')
 
       it "wires outlet referenecs to elements with 'outlet' attributes", ->
         expect(view.li1).toMatchSelector "li.foo:contains(one)"

--- a/src/space-pen.coffee
+++ b/src/space-pen.coffee
@@ -1,7 +1,9 @@
 if typeof require is 'function'
   $ = jQuery = require('./jquery-extensions')
+  _ = require 'underscore-plus'
 else
   $ = jQuery = window.jQuery
+  _ = window._
 
 Tags =
   'a abbr address article aside audio b bdi bdo blockquote body button
@@ -197,7 +199,7 @@ class Builder
   openTag: (name, attributes) ->
     attributePairs =
       for attributeName, value of attributes
-        "#{attributeName}=\"#{value}\""
+        "#{_.dasherize attributeName}=\"#{value}\""
 
     attributesString =
       if attributePairs.length


### PR DESCRIPTION
As the title says, this patch turns camelCasedAttributes into dashed-attributes.

I think it's a worthwhile change because
- `@div dataMultiWordAttribute: …` looks nicer (and is easier to type IMO) than `@div 'data-multi-word-attribute': …`
- HTML attributes are not case sensitive, so it shouldn't break anything.
-  it doesn't add any new dependencies because underscore-plus was already being used elsewhere in the source.
-  jQuery itself applies the same transformation (and its reverse) in many places, including CSS properties and data attributes.
