### PR TITLE
Make "=>" function binding optional

### DIFF
--- a/spec/jquery-extensions-spec.coffee
+++ b/spec/jquery-extensions-spec.coffee
@@ -41,8 +41,8 @@ describe 'jQuery extensions', ->
   describe "$.fn.events() and $.fn.document(...)", ->
     it "returns a list of all events being listened for on the target node or its ancestors, along with their documentation string", ->
       view = $$ ->
-        @div id: 'a', =>
-          @div id: 'b', =>
+        @div id: 'a', ->
+          @div id: 'b', ->
             @div id: 'c'
           @div id: 'd'
 
@@ -76,7 +76,7 @@ describe 'jQuery extensions', ->
 
     beforeEach ->
       view = $$ ->
-        @div class: 'a', =>
+        @div class: 'a', ->
           @div class: 'b'
           @div class: 'c'
       handler = jasmine.createSpy("commandHandler")
@@ -118,7 +118,7 @@ describe 'jQuery extensions', ->
 
   describe "$.fn.scrollUp/Down/ToTop/ToBottom", ->
     it "scrolls the element in the specified way if possible", ->
-      view = $$ -> @div => _.times 20, => @div('A')
+      view = $$ -> @div -> _.times 20, => @div('A')
       view.css(height: 100, width: 100, overflow: 'scroll')
       view.appendTo($('#jasmine-content'))
 
@@ -175,7 +175,7 @@ describe 'jQuery extensions', ->
     describe "$.fn.hasFocus()", ->
       it "returns true if the element is focused or contains an element that is focused", ->
         $('#jasmine-content').append $$ ->
-          @div id: 'parent', tabindex: -1, =>
+          @div id: 'parent', tabindex: -1, ->
             @div id: 'child', tabindex: -1
         parent = $('#parent')
         child = $('#child')
@@ -197,12 +197,12 @@ describe 'jQuery extensions', ->
 
     class ChildView extends View
       @content: ->
-        @div class: 'child', =>
+        @div class: 'child', ->
           @subview 'grandchild', new GrandchildView
 
     class ParentView extends View
       @content: ->
-        @div class: 'parent', =>
+        @div class: 'parent', ->
           @subview 'child', new ChildView
 
     [parentView, event] = []

--- a/spec/space-pen-spec.coffee
+++ b/spec/space-pen-spec.coffee
@@ -7,7 +7,7 @@ describe "View", ->
     beforeEach ->
       class Subview extends View
         @content: (params={}, otherArg) ->
-          @div =>
+          @div ->
             @h2 { outlet: "header" }, params.title + " " + otherArg
             @div "I am a subview"
             @tag 'mytag', id: 'thetag', 'Non standard tag'
@@ -17,13 +17,13 @@ describe "View", ->
 
       class TestView extends View
         @content: (params={}, otherArg) ->
-          @div keydown: 'viewClicked', class: 'rootDiv', =>
+          @div keydown: 'viewClicked', class: 'rootDiv', ->
             @h1 { outlet: 'header' }, params.title + " " + otherArg
             @list()
             @subview 'subview', new Subview(title: "Subview", 43)
 
         @list: ->
-          @ol =>
+          @ol ->
             @li outlet: 'li1', click: 'li1Clicked', class: 'foo', "one"
             @li outlet: 'li2', keypress:'li2Keypressed', class: 'bar', "two"
 
@@ -116,7 +116,7 @@ describe "View", ->
       it "throws an exception if the view has a self closing tag with text", ->
         BadView = class extends View
           @content: ->
-            @div =>
+            @div ->
               @img 'text'
 
         expect(-> new BadView).toThrow("Self-closing tag img cannot have text or content")
@@ -227,8 +227,8 @@ describe "View", ->
   describe "View.render (bound to $$)", ->
     it "renders a document fragment based on tag methods called by the given function", ->
       fragment = $$ ->
-        @div class: "foo", =>
-          @ol =>
+        @div class: "foo", ->
+          @ol ->
             @li id: 'one'
             @li id: 'two'
 
@@ -239,7 +239,7 @@ describe "View", ->
 
     it "renders subviews", ->
       fragment = $$ ->
-        @div =>
+        @div ->
           @subview 'foo', $$ ->
             @div id: "subview"
 
@@ -249,8 +249,8 @@ describe "View", ->
   describe "$$$", ->
     it "returns the raw HTML constructed by tag methods called by the given function (not a jQuery wrapper)", ->
       html = $$$ ->
-        @div class: "foo", =>
-          @ol =>
+        @div class: "foo", ->
+          @ol ->
             @li id: 'one'
             @li id: 'two'
 

--- a/src/space-pen.coffee
+++ b/src/space-pen.coffee
@@ -58,17 +58,17 @@ class View extends jQuery
   @builderStack: null
 
   Tags.forEach (tagName) ->
-    View[tagName] = (args...) -> @currentBuilder.tag(tagName, args...)
+    View[tagName] = (args...) -> @currentBuilder.tag(@, tagName, args...)
 
   # Public: Add the given subview wired to an outlet with the given name
   @subview: (name, view) ->
-    @currentBuilder.subview(name, view)
+    @currentBuilder.subview(@, name, view)
 
   # Public: Add a text node with the given text content
   @text: (string) -> @currentBuilder.text(string)
 
   # Public: Add a new tag with the given name
-  @tag: (tagName, args...) -> @currentBuilder.tag(tagName, args...)
+  @tag: (tagName, args...) -> @currentBuilder.tag(@, tagName, args...)
 
   # Public: Add new child DOM nodes from the given raw HTML string.
   @raw: (string) -> @currentBuilder.raw(string)
@@ -181,7 +181,7 @@ class Builder
   buildHtml: ->
     [@document.join(''), @postProcessingSteps]
 
-  tag: (name, args...) ->
+  tag: (context, name, args...) ->
     options = @extractOptions(args)
 
     @openTag(name, options.attributes)
@@ -190,7 +190,7 @@ class Builder
       if options.text? or options.content?
         throw new Error("Self-closing tag #{name} cannot have text or content")
     else
-      options.content?()
+      options.content?.call context
       @text(options.text) if options.text
       @closeTag(name)
 
@@ -223,9 +223,9 @@ class Builder
   raw: (string) ->
     @document.push string
 
-  subview: (outletName, subview) ->
+  subview: (context, outletName, subview) ->
     subviewId = "subview-#{++idCounter}"
-    @tag 'div', id: subviewId
+    @tag context, 'div', id: subviewId
     @postProcessingSteps.push (view) ->
       view[outletName] = subview
       subview.parentView = view


### PR DESCRIPTION
Not sure if theres a particular reason for wanting all the tag `options.content` functions to use function binding with the fat arrow. But its not too difficult to change it without any breaking changes.

``` coffee
@div id: 'a', =>
  @div id: 'b'
# becomes
@div id: 'a', ->
  @div id: 'b'
```

---

and in javascript, this:

``` js
return this.div({
  id: 'a'
}, (function(_this) {
  return function() {
    return _this.div({
      id: 'b'
    });
  };
})(this));
```

can become this:

``` js
return this.div({
  id: 'a'
}, function() {
  return this.div({
    id: 'b'
  });
});
```

the only benefit I can think of for `=>`, is that `_this` gets minified into a single character, and in a really large view, that can save bytes.
