### PR TITLE
Added bower package manifest file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,32 @@
+{
+  "name": "space-pen",
+  "version": "3.2.0",
+  "homepage": "https://github.com/atom/space-pen",
+  "authors": [
+    "Kevin Sawicki <kevinsawicki@gmail.com>",
+    "nathansobo <nathan@github.com>"
+  ],
+  "description": "A simple and powerful client-side view framework that works in zero-gravity.",
+  "main": "./lib/space-pen.js",
+  "keywords": [
+    "view-engine"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "*.html",
+    "node_modules",
+    "bower_components",
+    "src",
+    "spec",
+    "examples",
+    "benchmark",
+    "vendor",
+    "Gruntfile.coffee",
+    "package.json"
+  ],
+  "dependencies": {
+    "underscore-plus": "1.x",
+    "jquery": "2.x"
+  }
+}


### PR DESCRIPTION
As discussed in issue #41, this PR contains the package manifest file for bower.

There are a couple of things to note. Bower works directly against the git repository, the bower repo itself does not contain any of the source itself. This means that which ever tag the bower package is pointing to needs to have the `lib` folder (or something similar) present.  

If committing `lib` to master isn't something you want to do, you can see what jquery does [here](https://github.com/jquery/jquery/tree/2.1.1). You will note that they only commit the `dist` folder to the "release" branch.

Instructions for registering the package can be found [here](http://bower.io/#registering-packages).
