### PR TITLE
Support building SpacePen wrappers around existing DOM nodes

### DIFF
--- a/src/space-pen.coffee
+++ b/src/space-pen.coffee
@@ -109,17 +109,25 @@ class View extends jQuery
     step(fragment) for step in postProcessingSteps
     fragment
 
+  element: null
+
   constructor: (args...) ->
-    [html, postProcessingSteps] = @constructor.buildHtml -> @content(args...)
-    jQuery.fn.init.call(this, html)
-    throw new Error("View markup must have a single root element") if @length != 1
+    if @element?
+      jQuery.fn.init.call(this, @element)
+    else
+      [html, postProcessingSteps] = @constructor.buildHtml -> @content(args...)
+      jQuery.fn.init.call(this, html)
+      throw new Error("View markup must have a single root element") if @length != 1
+      @element = @[0]
+
     @wireOutlets(this)
     @bindEventHandlers(this)
-    jQuery.data(@[0], 'view', this)
-    for element in @[0].getElementsByTagName('*')
+    jQuery.data(@element, 'view', this)
+    for element in @element.getElementsByTagName('*')
       jQuery.data(element, 'view', this)
-    @[0].setAttribute('callAttachHooks', true)
-    step(this) for step in postProcessingSteps
+    @element.setAttribute('callAttachHooks', true)
+    if postProcessingSteps?
+      step(this) for step in postProcessingSteps
     @initialize?(args...)
 
   buildHtml: (params) ->


### PR DESCRIPTION
In order to keep the existing SpacePen API in a deprecated form while migrating off of jQuery in core, we need a way to wrap custom elements in SpacePen rather than having the view generate its own content. This PR adds the ability to pre-assign the `::element` property to a DOM node in the constructor before calling `super`, in which case the view will wrap the existing node rather than generating its own content. All of the permanent view logic can then be moved into the custom element, leaving the SpacePen view as a shim.
