### PR TITLE
Replaced $.attr with $.prop for disabled checks

### DIFF
--- a/src/space-pen.coffee
+++ b/src/space-pen.coffee
@@ -347,13 +347,13 @@ $.fn.isHidden = ->
     getComputedStyle(this[0]).display == 'none'
 
 $.fn.isDisabled = ->
-  !!@attr('disabled')
+  Boolean(@prop('disabled'))
 
 $.fn.enable = ->
-  @removeAttr('disabled')
+  @prop('disabled', false)
 
 $.fn.disable = ->
-  @attr('disabled', 'disabled')
+  @prop('disabled', true)
 
 $.fn.insertAt = (index, element) ->
   target = @children(":eq(#{index})")


### PR DESCRIPTION
As mentioned by Mark Kahn in
https://github.com/atom-archive/space-pen/issues/64, this replaces the usage of `attr` with `prop`, according to the documentation on the [jQuery API page](https://api.jquery.com/prop). I replaced `removeAttr` with `prop`, as using `removeProp` with the _disabled_ property is not recommended.

I ran the tests on Linux

```
$ uname -a
Linux bto 3.16.0-4-amd64 #1 SMP Debian 3.16.36-1+deb8u1 (2016-09-03) x86_64 GNU/Linux
```
